### PR TITLE
Suppress mode when keyboard macros are executing

### DIFF
--- a/smooth-scrolling.el
+++ b/smooth-scrolling.el
@@ -186,6 +186,9 @@ lines of the top of the window."
    (let ((lines-from-window-top
           (smooth-scroll-lines-from-window-top)))
      (and
+      ;; [GitHub Issue #5] Keyboard macros execute in interactive mode so
+      ;; we need to be careful not to do anything.
+      (not executing-kbd-macro)
       ;; Only scroll down if we're within the top margin
       (<= lines-from-window-top smooth-scroll-margin)
       ;; Only scroll down if we're in the top half of the window
@@ -205,6 +208,9 @@ lines of the top of the window."
   "Scroll up smoothly if cursor is within `smooth-scroll-margin'
 lines of the bottom of the window."
   (and
+   ;; [GitHub Issue #5] Keyboard macros execute in interactive mode so
+   ;; we need to be careful not to do anything.
+   (not executing-kbd-macro)
    ;; Only scroll up if there is buffer below the end of the window.
    (< (window-end) (buffer-end 1))
    (let ((lines-from-window-bottom


### PR DESCRIPTION
This fixes #5 by disabling the scroll code whenever we detect that a
keyboard macro is currently executing. This is to address the underlying
cause of early termination of macros as the `scroll-scroll-*` functions
can yield an error by attempting to scroll when we cannot.

NOTE: If the throwing of "End of Buffer" causes other issues we should
      remove this temporary fix and address the root cause of the error.
