### PR TITLE
Rewrite as global minor mode

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,8 +23,9 @@ for the gory details.
 Put somewhere on your <tt>load-path</tt> and include
 ```
    (require 'smooth-scrolling)
+   (smooth-scrolling-mode 1)
 ```
- in your initialization file.
+in your initialization file. To turn it on or off, use `M-x smooth-scrolling-mode`.
  
 ## Notes
 This only affects the behaviour of the <tt>next-line</tt> and


### PR DESCRIPTION
In the process of converting this to a minor mode, I accidentally
complete rewrite :/ I simplified the logic by unifying the scroll-up and
scroll-down functions into just one function called "do-auto-scroll". I
eliminated the dependency on "window-end", which can sometimes be nil,
so there is no longer a need to set "redisplay-dont-pause" to t. When
enabled and disabled, the mode saves and restores the value of
"scroll-margin", so after disabling it, scroll behavior should be fully
restored to what it was.

Also, instead of special-casing the keyboard macro issue, I just
suppress all scrolling-related errors while doing smooth scrolling. This
allows the mode to avoid interfering with things that expect scrolling
to work a certain way.

Note that autoloads are only required on the custom variables, because
you have to enable the mode before it does anything, and that will
trigger loading the mode. I've also put an autoload on the
`enable-smooth-scroll-for-function` macro so users can easily use it in
their config to enable smooth scrolling for other commands.